### PR TITLE
Adición de licencia

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,18 @@
+/*
+    Copyright @ZettaPloom
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,MA 02110-1301,USA.
+*/
+
 /* ***************************************************************
 Para correr este programa instalar la libreria libjsoncpp-dev
 En Linux: sudo apt-get install libjsoncpp-dev


### PR DESCRIPTION
La recomendación GNU es incluír su encabezado de licencia en cada fuente