### PR TITLE
Fix: Cannot open shared object file libjsoncpp.so

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # Analizador-lexico
 Escriba su código en el archivo "Codigo.al" tenga en cuenta que no se reconocen espacios
 y SIEMPRE un salto de linea es con ";"
+
+__Importante__: Usuarios sin paquetes de desarrollo instalados pueden requerir el uso de la librería para manipulación de archivos en notación de objetos de JavaScript (JSON):
+Para instalar en OS derivados debian:
+``
+apt-get install libjsoncpp-dev
+``


### PR DESCRIPTION
Usuarios sin librerías pueden visualizar dicho error en tiempo de ejecución/compilación